### PR TITLE
Fix resampling offset and document inclusive slices

### DIFF
--- a/lexi/lexi.py
+++ b/lexi/lexi.py
@@ -41,6 +41,8 @@ class LEXI:
                 3. A float in the format of a UNIX timestamp (e.g. 1640995200.0)
                 This time range defines the time range of the ephemeris data and the time range of
                 the LEXI data.
+            Note that endpoints are inclusive (the end time is a closed interval); this is because
+            the time range slicing is done with pandas, and label slicing in pandas is inclusive.
         t_step: float
             Time step in seconds for time resolution of the look direction datum.
         t_integrate: float
@@ -381,7 +383,7 @@ class LEXI:
 
             # Slice to relevant time range; make groups of rows spanning t_integration
             integ_groups = spc_df[self.t_range[0] : self.t_range[1]].resample(
-                pd.Timedelta(self.t_integrate, unit="s")
+                pd.Timedelta(self.t_integrate, unit="s"), origin="start"
             )
 
             # Make as many empty exposure maps as there are integration groups
@@ -645,7 +647,7 @@ class LEXI:
 
         # Slice to relevant time range; make groups of rows spanning t_integration
         integ_groups = photons[self.t_range[0] : self.t_range[1]].resample(
-            pd.Timedelta(self.t_integrate, unit="s")
+            pd.Timedelta(self.t_integrate, unit="s"), origin="start"
         )
 
         # Make as many empty lexi histograms as there are integration groups

--- a/lexi_test_script.py
+++ b/lexi_test_script.py
@@ -6,10 +6,10 @@ lexi = LEXI(
     {
         "t_range": [
             "2024-07-08T15:01:00",
-            "2024-07-09T15:01:00",
+            "2024-07-09T15:00:00",
         ],  # Ephemeris data timerange
         # "t_range": ["2024-05-23T21:43:41","2024-05-23T21:48:41"], # Ramiz's PIT data timerange
-        "t_integrate": 60 * 60 * 24,  # 12 hours # usually couple secs to (10m) to hour
+        "t_integrate": 60 * 60 * 12,  # 12 hours # usually couple secs to (10m) to hour
         "t_step": 3,  # 1, #30
         "ra_range": [325.0, 365.0],
         "dec_range": [-21.0, 6.0],


### PR DESCRIPTION
Two different things were causing resampling windows to behave a bit weirdly, which is why e.g. our 24 hour integration time over two endpoints 24 hours apart yielded 2 integration windows and not 1.

1. Pandas: Slice endpoints are inclusive: https://pandas.pydata.org/docs/user_guide/advanced.html#advanced-endpoints-are-inclusive

2. Pandas: Clever resampling can cause unexpected inconsistencies: https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#use-origin-or-offset-to-adjust-the-start-of-the-bins

What thing 2 meant was basically that if our start time was e.g. 15h, and we set an integration time of 12h, pandas observed that 12h neatly divides the day in two, so it took the first integration window to be 12h->0h instead of 15h->3h, and so on - so that a time range of 15h on one day to 15h the next day actually spans three "12 hour integration windows". This PR specifies "origin=start" to fix that issue.

Issue 1 apparently cannot be fixed without moving away from pandas time slicing entirely, so this PR merely documents the quirk.

---

As for the sparse data windowing problem - still working on it... :coffin: 