### PR TITLE
Handle sparse data

### DIFF
--- a/lexi/lexi.py
+++ b/lexi/lexi.py
@@ -902,19 +902,29 @@ class LEXI:
             edgecolor = "k"
 
         if v_min is None and v_max is None:
+            array_min = np.nanmin(input_array)
+            array_max = np.nanmax(input_array)
+            if array_min == array_max:
+                # In theory, could be a real instance of a perfectly flat map;
+                # probably, just an integration window with no photons.
+                print(f"Encountered map where array min {array_min} == array max {array_max}. "
+                      f"Plotting a range of +- 1.")
+                array_min -= 1
+                array_max += 1
+
             if norm_type == "linear":
-                v_min = 0.9 * np.nanmin(input_array)
-                v_max = 1.1 * np.nanmax(input_array)
+                v_min = 0.9 * array_min
+                v_max = 1.1 * array_max
                 norm = mpl.colors.Normalize(vmin=v_min, vmax=v_max)
             elif norm_type == "log":
-                if np.nanmin(input_array) <= 0:
+                if array_min <= 0:
                     v_min = 1e-5
                 else:
-                    v_min = np.nanmin(input_array)
-                if np.nanmax(input_array) <= 0:
+                    v_min = array_min
+                if array_max <= 0:
                     v_max = 1e-1
                 else:
-                    v_max = np.nanmax(input_array)
+                    v_max = array_max
                 norm = mpl.colors.LogNorm(vmin=v_min, vmax=v_max)
         elif v_min is not None and v_max is not None:
             if norm_type == "linear":


### PR DESCRIPTION
This PR fixes the code for cases where the ephemeris and/or photon data do not span the entire time range requested by the user, or where there are "holes" in the photon data (stretches of time longer than t_integrate, in which there is no photon strike), so that the exposure map/sky background/lexi image arrays always have the same length, and the time windows all line up, and therefore the arrays can be correctly multiplied with/subtracted from each other.

Re last commit 4f7562b: I wrote that before rebasing onto stable and seeing the new logic for if norm type = log and vmin/vmax <= 0 ... It looks like it makes sense to have one fix or the other fix but not both?? Anyway, pls feel free to drop that commit entirely, or just comment and I will delete it, etc etc 