### PR TITLE
Exp map: Take modulo ops out of loop

### DIFF
--- a/lexi/lexi.py
+++ b/lexi/lexi.py
@@ -440,21 +440,25 @@ class LEXI:
             # Make as many empty exposure maps as there are integration groups
             exposure_maps = np.zeros((len(integ_groups), len(ra_arr), len(dec_arr)))
 
-            # TODO: Can we figure out a way to do this not in a loop??? Cannot be vectorized...
             # Loop through each pointing step and add the exposure to the map
+            # Wrap-proofing: First make everything [0,360)...
+            ra_grid_mod = ra_grid % 360
+            dec_grid_mod = dec_grid % 360
             for map_idx, (_, group) in enumerate(integ_groups):
                 for row in group.itertuples():
                     # Get distance in degrees to the pointing step
                     # Wrap-proofing: First make everything [0,360), then +-360 on second operand
+                    row_ra_mod = row.ra % 360
+                    row_dec_mod = row.dec % 360
                     ra_diff = np.minimum(
-                        abs((ra_grid % 360) - (row.ra % 360)),
-                        abs((ra_grid % 360) - (row.ra % 360 - 360)),
-                        abs((ra_grid % 360) - (row.ra % 360 + 360)),
+                        abs(ra_grid_mod - row_ra_mod),
+                        abs(ra_grid_mod - (row_ra_mod - 360)),
+                        abs(ra_grid_mod - (row_ra_mod + 360)),
                     )
                     dec_diff = np.minimum(
-                        abs((dec_grid % 360) - (row.dec % 360)),
-                        abs((dec_grid % 360) - (row.dec % 360 - 360)),
-                        abs((dec_grid % 360) - (row.dec % 360 + 360)),
+                        abs(dec_grid_mod - row_dec_mod),
+                        abs(dec_grid_mod - (row_dec_mod - 360)),
+                        abs(dec_grid_mod - (row_dec_mod + 360)),
                     )
                     r = np.sqrt(ra_diff**2 + dec_diff**2)
                     # Make an exposure delta for this span


### PR DESCRIPTION
Sorry to rise from the dead, but this was a crime against programming... 


With the following test params/script (and the same fake ephemeris data) this change took my exposure map time from 18ish to 8ish seconds
```
# Import LEXI
from lexi.lexi import LEXI

# Set up a LEXI instance
lexi = LEXI(
    {
        "t_range": [
            "2024-07-08T21:43:41",
            #"2024-07-08T21:47:48",
            "2024-07-12T21:48:41",
        ],
        "t_integrate": 60 * 10, # 10 minutes
        "t_step": 5,  # 1, #30
        "ra_range": [0, 360],
        "dec_range": [0, 360],
        "ra_res": 4,
        "dec_res": 3,
        "save_exposure_maps": False,
        "save_sky_backgrounds": False,
        "save_lexi_images": False,
    }
)

# Get space params
# spaceparams = lexi.get_spc_prams()
# Get exposure maps
expmaps, ra_arr, dec_arr = lexi.get_exposure_maps()
# Get sky backgrounds
# skybgs, ra_arr, dec_arr = lexi.get_sky_backgrounds()
# Get background corrected images
#hists, ra_arr, dec_arr = lexi.get_lexi_images()
```