### PR TITLE
fixed a relative import error

### DIFF
--- a/lexi/lexi.py
+++ b/lexi/lexi.py
@@ -9,7 +9,7 @@ from cdflib import CDF
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import warnings
-from . import __version__, __doc__
+from lexi import __version__, __doc__
 
 # Add the docstring to the package
 __doc__ = __doc__


### PR DESCRIPTION
in `lexi.py` changed `from . import __version__, __doc__` to `from lexi import __version__, __doc__`