### PR TITLE
88 multiple images for a single integration time

### DIFF
--- a/lexi_sample_code.py
+++ b/lexi_sample_code.py
@@ -1,6 +1,8 @@
 from lexi_xray import lexi as lexi
 import importlib
 import pandas as pd
+from pathlib import Path
+import shutil
 
 import numpy as np
 
@@ -110,20 +112,29 @@ input_params = {
 # print(df1, df2, df3)
 # print(input_params["time_range"])
 # exposure_maps_dict = lexi.calc_exposure_maps(**input_params)
-
+# Delete the `data` folder and its contents and `figures` folder and its contents before running this
+# code using Path even if the fodlers are not empty
+# shutil.rmtree(Path("data"), ignore_errors=True)
+# shutil.rmtree(Path("figures"), ignore_errors=True)
+#
 lexi_images_dict = lexi.make_lexi_images(
-    time_range=["2025-03-04 08:53:41", "2025-03-04 09:23:49"],
+    time_range=["2025-03-04 08:53:41", "2025-03-05 09:23:46"],
     ra_range=[190, 310],
     dec_range=[-33, 3],
     ra_res=0.5,
     dec_res=0.5,
-    time_integrate=600,
+    time_step=0.5,
+    # time_integrate=600.23,
     background_correction_on=True,
     save_exposure_map_file=True,
     save_sky_backgrounds_file=True,
     save_exposure_map_image=True,
     save_sky_backgrounds_image=True,
     save_lexi_images=True,
+    verbose=False,
+    array_to_image_kwargs={
+        "norm_type": "log",
+    },
 )
 # exposure_maps = exposure_maps_dict["exposure_maps"]
 print(f"the shape of exposure_maps is {np.shape(lexi_images_dict['lexi_images'])}")

--- a/lexi_sample_code.py
+++ b/lexi_sample_code.py
@@ -2,8 +2,8 @@ from lexi_xray import lexi as lexi
 import importlib
 import pandas as pd
 
-# import numpy as np
-#
+import numpy as np
+
 importlib.reload(lexi)
 
 array_to_image_kwargs_exp = {
@@ -75,7 +75,7 @@ array_to_image_kwargs_lex = {
     "cbar_label": "Counts",
     "cbar_orientation": "vertical",
     "show_axes": True,
-    "display": False,
+    "display": True,
     "figure_size": (5, 5),
     "figure_format": "png",
     "figure_font_size": 12,
@@ -94,12 +94,12 @@ input_params = {
     "ra_range": [190, 240],
     "dec_range": [-30, -10],
     "save_exposure_map_file": True,
-    "save_exposure_map_image": False,
-    "save_sky_backgrounds_file": True,
-    "save_sky_backgrounds_image": False,
-    "save_lexi_images": True,
+    "save_exposure_map_image": True,
+    # "save_sky_backgrounds_file": True,
+    # "save_sky_backgrounds_image": False,
+    # "save_lexi_images": True,
     "verbose": True,
-    "background_correction_on": True,
+    # "background_correction_on": True,
     "array_to_image_kwargs": array_to_image_kwargs_lex,
 }
 
@@ -109,10 +109,24 @@ input_params = {
 # df1, df2, df3 = lexi.get_spc_prams(**input_params)
 # print(df1, df2, df3)
 # print(input_params["time_range"])
-# exposure_maps_dict = lexi.get_lexi_images(**input_params)
+# exposure_maps_dict = lexi.calc_exposure_maps(**input_params)
 
+lexi_images_dict = lexi.make_lexi_images(
+    time_range=["2025-03-04 08:53:41", "2025-03-04 09:23:49"],
+    ra_range=[190, 310],
+    dec_range=[-33, 3],
+    ra_res=0.5,
+    dec_res=0.5,
+    time_integrate=600,
+    background_correction_on=True,
+    save_exposure_map_file=True,
+    save_sky_backgrounds_file=True,
+    save_exposure_map_image=True,
+    save_sky_backgrounds_image=True,
+    save_lexi_images=True,
+)
 # exposure_maps = exposure_maps_dict["exposure_maps"]
-
+print(f"the shape of exposure_maps is {np.shape(lexi_images_dict['lexi_images'])}")
 # print(np.shape(exposure_maps))
 # print(np.shape(exposure_maps[0]))
 # print(np.nanmin(exposure_maps[0]), np.nanmax(exposure_maps[0]))
@@ -125,9 +139,9 @@ input_params = {
 # print(np.shape(lexi_images_dict["lexi_images"]))
 
 
-lexi.get_lexi_data(
-    time_range=[
-        pd.to_datetime("2025-03-04 08:53:41"),
-        pd.to_datetime("2025-03-04 09:23:41"),
-    ]
-)
+# lexi.get_lexi_data(
+#     time_range=[
+#         pd.to_datetime("2025-03-04 08:53:41"),
+#         pd.to_datetime("2025-03-04 09:23:41"),
+#     ]
+# )

--- a/lexi_xray/lexi.py
+++ b/lexi_xray/lexi.py
@@ -1342,12 +1342,31 @@ def calc_exposure_maps(
             pd.Timedelta(time_integrate, unit="s"), origin="start"
         )
 
+        resampled_groups = spc_df.resample(
+            pd.Timedelta(time_integrate, unit="s"), origin="start"
+        )
+
+        # Filter out groups that fall outside the time_range
+        integ_groups = [
+            group
+            for _, group in resampled_groups
+            if not group.empty
+            and group.index.min() >= time_range[0]
+            and group.index.max() <= time_range[1]
+        ]
+
+        # Filter out the groups if their minimum and maximum times are same
+        integ_groups = [
+            group for group in integ_groups if group.index.min() != group.index.max()
+        ]
+
         # Get the min and max times of each group
         start_time_arr = []
         stop_time_arr = []
-        for _, group in integ_groups:
+        for group in integ_groups:
             start_time_arr.append(group.index.min())
             stop_time_arr.append(group.index.max())
+
         # Make as many empty exposure maps as there are integration groups
         exposure_maps = np.zeros((len(integ_groups), len(ra_arr), len(dec_arr)))
 
@@ -1356,7 +1375,7 @@ def calc_exposure_maps(
         ra_grid_mod = ra_grid  # % 360
         dec_grid_mod = dec_grid  # % 90
 
-        for map_idx, (_, group) in enumerate(integ_groups):
+        for map_idx, (group) in enumerate(integ_groups):
             for row in group.itertuples():
                 # Get distance in degrees to the pointing step
                 # Wrap-proofing: First make everything [0,360), then +-360 on second operand
@@ -1444,6 +1463,8 @@ def calc_exposure_maps(
             array_to_image_kwargs["x_range"] = ra_range
         if "y_range" not in array_to_image_kwargs:
             array_to_image_kwargs["y_range"] = dec_range
+        if "save" not in array_to_image_kwargs:
+            array_to_image_kwargs["save"] = save_exposure_map_image
         for i, exposure in enumerate(exposure_maps_dict["exposure_maps"]):
             array_to_image(
                 input_array=exposure,
@@ -1775,6 +1796,8 @@ def calc_sky_backgrounds(
             array_to_image_kwargs["x_range"] = ra_range
         if "y_range" not in array_to_image_kwargs:
             array_to_image_kwargs["y_range"] = dec_range
+        if "save" not in array_to_image_kwargs:
+            array_to_image_kwargs["save"] = save_sky_backgrounds_image
         for i, sky_background in enumerate(sky_backgrounds_dict["sky_backgrounds"]):
             array_to_image(
                 input_array=sky_background,
@@ -2135,6 +2158,10 @@ def make_lexi_images(
         # NOTE: Chnage the factor of 0.001 in the line below to the actual factor that should be
         # (ideallly 1)
         sky_backgrounds = 0.01 * sky_backgrounds_dict["sky_backgrounds"]
+        # Print the shape of the sky_backgrounds
+
+        print(f"Shape of the sky_backgrounds: {sky_backgrounds.shape}")
+        print(f"Shape of the histograms: {histograms.shape}")
         histograms = np.maximum(histograms - sky_backgrounds, 0)
 
     # Define a dictionary to store the histograms, ra_arr, and dec_arr, time_range, and time_integrate,
@@ -2165,6 +2192,8 @@ def make_lexi_images(
             array_to_image_kwargs["x_range"] = ra_range
         if "y_range" not in array_to_image_kwargs:
             array_to_image_kwargs["y_range"] = dec_range
+        if "save" not in array_to_image_kwargs:
+            array_to_image_kwargs["save"] = save_lexi_images
         for i, histogram in enumerate(lexi_images_dict["lexi_images"]):
             array_to_image(
                 input_array=histogram,
@@ -2512,7 +2541,7 @@ def array_to_image(
         if save_path is None:
             save_path = Path.cwd() / f"figures/{key}"
             if verbose:
-                print("save_path not provided. Saving figure to default lcoation \n")
+                print("save_path not provided. Saving figure to default location \n")
         Path(save_path).mkdir(parents=True, exist_ok=True)
         if save_name is None or save_name == "default":
             start_time_str = start_time.strftime("%Y%m%d_%H%M%S")

--- a/lexi_xray/lexi.py
+++ b/lexi_xray/lexi.py
@@ -620,7 +620,7 @@ def get_lexi_data(
 def get_spc_prams(
     time_range: list = None,
     time_zone: str = "UTC",
-    time_step: float = 5,
+    time_step: float = 1,
     time_pad: float = 300,
     data_clip: bool = True,
     interp_method: str = "linear",
@@ -775,7 +775,7 @@ def get_spc_prams(
     # Validate time_step
     time_step_validated = validate_input("time_step", time_step)
     if not time_step_validated:
-        time_step = 5
+        time_step = 1
 
     # Validate interp_method
     interp_method_validated = validate_input("interp_method", interp_method)
@@ -1069,7 +1069,7 @@ def calc_exposure_maps(
     time_range: list = None,
     time_zone: str = "UTC",
     interp_method: str = "linear",
-    time_step: float = 5,
+    time_step: float = 1,
     ra_range: list = [0, 360],
     dec_range: list = [-90, 90],
     ra_res: float = 0.5,
@@ -1226,7 +1226,7 @@ def calc_exposure_maps(
     # Validate time_step
     time_step_validated = validate_input("time_step", time_step)
     if not time_step_validated:
-        time_step = 5
+        time_step = 1
         if verbose:
             print(
                 f"\033[1;91m Time step \033[1;92m (time_step) \033[1;91m not provided. Setting time step to \033[1;92m {time_step} seconds \033[0m\n"
@@ -1252,6 +1252,7 @@ def calc_exposure_maps(
     spc_df = get_spc_prams(
         time_range=time_range,
         time_zone=time_zone,
+        time_step=time_step,
         interp_method=interp_method,
         verbose=verbose,
     )
@@ -1338,10 +1339,6 @@ def calc_exposure_maps(
         print("Exposure map not found, computing now. This may take a while \n")
 
         # Slice to relevant time range; make groups of rows spanning time_integratetion
-        integ_groups = spc_df[time_range[0] : time_range[1]].resample(
-            pd.Timedelta(time_integrate, unit="s"), origin="start"
-        )
-
         resampled_groups = spc_df.resample(
             pd.Timedelta(time_integrate, unit="s"), origin="start"
         )
@@ -1359,7 +1356,6 @@ def calc_exposure_maps(
         integ_groups = [
             group for group in integ_groups if group.index.min() != group.index.max()
         ]
-
         # Get the min and max times of each group
         start_time_arr = []
         stop_time_arr = []
@@ -1474,6 +1470,7 @@ def calc_exposure_maps(
                 ra_res=ra_res,
                 dec_res=dec_res,
                 time_integrate=exposure_maps_dict["time_integrate"],
+                figure_title="Exposure Map",
                 **(array_to_image_kwargs if array_to_image_kwargs else {}),
             )
 
@@ -1484,7 +1481,7 @@ def calc_sky_backgrounds(
     time_range: list = None,
     time_zone: str = "UTC",
     interp_method: str = "linear",
-    time_step: float = 5,
+    time_step: float = 1,
     time_integrate: float = None,
     ra_range: list = [0, 360],
     dec_range: list = [-90, 90],
@@ -1582,6 +1579,8 @@ def calc_sky_backgrounds(
         Dictionary containing the following keys:
             - sky_backgrounds : numpy array
                 Sky backgrounds
+            - Exposure maps : numpy array
+                Exposure maps
             - ra_arr : numpy array
                 Right ascension array
             - dec_arr : numpy array
@@ -1648,7 +1647,6 @@ def calc_sky_backgrounds(
         print(sky_background_dict.keys())
 
     """
-
     # Get exposure maps
     exposure_maps_dict = calc_exposure_maps(
         time_range=time_range,
@@ -1745,6 +1743,7 @@ def calc_sky_backgrounds(
         # time_integrate, ra_range, and dec_range, ra_res, and dec_res, and save it to a pickle file
         sky_backgrounds_dict = {
             "sky_backgrounds": sky_backgrounds,
+            "exposure_maps": exposure_maps,
             "ra_arr": exposure_maps_dict["ra_arr"],
             "dec_arr": exposure_maps_dict["dec_arr"],
             "time_range": time_range,
@@ -1787,7 +1786,7 @@ def calc_sky_backgrounds(
     # If requested, save the sky background as an image
     if save_sky_backgrounds_image:
         if verbose:
-            print("Saving sky backgrounds as images")
+            print("Saving sky backgrounds as images...")
         # Check if the following keys are present in the array_to_image_kwargs dictionary, if not
         # then add them:
         # - x_range
@@ -1807,6 +1806,7 @@ def calc_sky_backgrounds(
                 ra_res=ra_res,
                 dec_res=dec_res,
                 time_integrate=sky_backgrounds_dict["time_integrate"],
+                figure_title="Sky Background",
                 **(array_to_image_kwargs if array_to_image_kwargs else {}),
             )
     # If the first element of sky_backgrounds shape is 1, then remove the first dimension
@@ -1819,7 +1819,7 @@ def make_lexi_images(
     time_range: list = None,
     time_zone: str = "UTC",
     interp_method: str = "linear",
-    time_step: float = 5,
+    time_step: float = 1,
     ra_range: list = [0, 360],
     dec_range: list = [-90, 90],
     ra_res: float = 0.5,
@@ -1917,6 +1917,10 @@ def make_lexi_images(
         Dictionary containing the following keys:
             - lexi_images : numpy array
                 LEXI images
+            - exposure_maps : numpy array
+                Exposure maps
+            - sky_backgrounds : numpy array
+                Sky backgrounds (if background_correction_on is True)
             - ra_arr : numpy array
                 Right ascension array
             - dec_arr : numpy array
@@ -2100,13 +2104,27 @@ def make_lexi_images(
     )
 
     # Slice to relevant time range; make groups of rows spanning time_integratetion
-    integ_groups = photons[time_range[0] : time_range[1]].resample(
+    resampled_groups = photons.resample(
         pd.Timedelta(time_integrate, unit="s"), origin="start"
     )
 
+    # Filter out groups that fall outside the time range
+    integ_groups = [
+        group
+        for _, group in resampled_groups
+        if not group.empty
+        and group.index.min() >= time_range[0]
+        and group.index.max() <= time_range[1]
+    ]
+
+    # Filter out the groups if their minimum and maximum times are the same
+    integ_groups = [
+        group for group in integ_groups if group.index.min() != group.index.max()
+    ]
+
     start_time_arr = []
     stop_time_arr = []
-    for _, group in integ_groups:
+    for group in integ_groups:
         start_time_val = group.index.min()
         stop_time_val = group.index.max()
         # If start and stop times are the same, then skip this group
@@ -2117,9 +2135,9 @@ def make_lexi_images(
             stop_time_arr.append(group.index.max())
 
     # Make as many empty lexi histograms as there are integration groups
-    histograms = np.zeros((len(start_time_arr), len(ra_arr), len(dec_arr)))
+    histograms = np.zeros((len(integ_groups), len(ra_arr), len(dec_arr)))
 
-    for hist_idx, (_, group) in enumerate(integ_groups):
+    for hist_idx, group in enumerate(integ_groups):
         # Loop through each photon strike and add it to the map
         for row in group.itertuples():
             try:
@@ -2164,21 +2182,76 @@ def make_lexi_images(
         print(f"Shape of the histograms: {histograms.shape}")
         histograms = np.maximum(histograms - sky_backgrounds, 0)
 
+        # NOTE: At this point, the histograms are background corrected and its units are counts in
+        # each bin. The next step is to conver the units to counts per second by dividing each bin by
+        # the exposure time of the LEXI image.
+        exposure_maps = sky_backgrounds_dict["exposure_maps"]
+        # Replace the zeros in the exposure maps and histograms with NaNs to avoid division by zero
+        exposure_maps = np.where(exposure_maps == 0, np.nan, exposure_maps)
+        histograms = np.where(histograms == 0, np.nan, histograms)
+        for i, exposure_map in enumerate(exposure_maps):
+            histograms[i] = histograms[i] / exposure_map
+    if not background_correction_on:
+        # Get the exposure maps
+        exposure_maps_dict = calc_exposure_maps(
+            time_range=time_range,
+            time_zone=time_zone,
+            interp_method=interp_method,
+            time_step=time_step,
+            ra_range=ra_range,
+            dec_range=dec_range,
+            ra_res=ra_res,
+            dec_res=dec_res,
+            time_integrate=time_integrate,
+            save_exposure_map_file=save_exposure_map_file,
+            save_exposure_map_image=save_exposure_map_image,
+            verbose=verbose,
+            array_to_image_kwargs=array_to_image_kwargs,
+        )
+        exposure_maps = exposure_maps_dict["exposure_maps"]
+
+        # Replace the zeros in the exposure_maps and histograms with NaNs to avoid division by zero
+        exposure_maps = np.where(exposure_maps == 0, np.nan, exposure_maps)
+        histograms = np.where(histograms == 0, np.nan, histograms)
+
+        # Convert the histograms to counts per second
+        for i, exposure_map in enumerate(exposure_maps):
+            histograms[i] = histograms[i] / exposure_map
+
     # Define a dictionary to store the histograms, ra_arr, and dec_arr, time_range, and time_integrate,
     # ra_range, and dec_range, ra_res, and dec_res, and save it to a pickle file
-    lexi_images_dict = {
-        "lexi_images": histograms,
-        "ra_arr": ra_arr,
-        "dec_arr": dec_arr,
-        "time_range": time_range,
-        "time_integrate": time_integrate,
-        "ra_range": ra_range,
-        "dec_range": dec_range,
-        "ra_res": ra_res,
-        "dec_res": dec_res,
-        "start_time_arr": start_time_arr,
-        "stop_time_arr": stop_time_arr,
-    }
+    if background_correction_on:
+        lexi_images_dict = {
+            "lexi_images": histograms,
+            "exposure_maps": exposure_maps,
+            "sky_backgrounds": sky_backgrounds,
+            "ra_arr": ra_arr,
+            "dec_arr": dec_arr,
+            "time_range": time_range,
+            "time_integrate": time_integrate,
+            "ra_range": ra_range,
+            "dec_range": dec_range,
+            "ra_res": ra_res,
+            "dec_res": dec_res,
+            "start_time_arr": start_time_arr,
+            "stop_time_arr": stop_time_arr,
+        }
+    if not background_correction_on:
+        lexi_images_dict = {
+            "lexi_images": histograms,
+            "exposure_maps": exposure_maps,
+            "ra_arr": ra_arr,
+            "dec_arr": dec_arr,
+            "time_range": time_range,
+            "time_integrate": time_integrate,
+            "ra_range": ra_range,
+            "dec_range": dec_range,
+            "ra_res": ra_res,
+            "dec_res": dec_res,
+            "start_time_arr": start_time_arr,
+            "stop_time_arr": stop_time_arr,
+        }
+
     print(start_time_arr)
     # If requested, save the histograms as images
     if save_lexi_images:
@@ -2226,7 +2299,7 @@ def array_to_image(
     ra_res: float = None,
     dec_res: float = None,
     time_integrate: float = None,
-    cmap: str = "viridis",
+    cmap: str = None,
     cmin: float = None,
     v_min: float = None,
     v_max: float = None,
@@ -2287,7 +2360,12 @@ def array_to_image(
         Default is None.
 
     cmap : str, optional
-        Colormap to use.  Default is 'viridis'.
+        Colormap to use. By default, based on the `key` being plotted it is set to the following:
+        - exposure_maps: 'cividis'
+        - sky_backgrounds: 'inferno'
+        - lexi_images: 'plasma'
+        - something else: 'viridis'
+        Default is 'viridis'. Other options include 'plasma', 'inferno', 'magma', 'cividis'. See https://matplotlib.org/stable/tutorials/colors/colormaps.html for more options.
 
     norm : mpl.colors.Normalize, optional
         Normalization to use for the colorbar colors.  Default is None.
@@ -2340,10 +2418,6 @@ def array_to_image(
         Figure object.
     ax : matplotlib.axes._subplots.AxesSubplot
         Axes object.
-
-    Example Usage
-    -------------
-    TODO: Add example usage
 
     """
     # Try to use latex rendering
@@ -2411,7 +2485,7 @@ def array_to_image(
             norm = mpl.colors.Normalize(vmin=v_min, vmax=v_max)
         elif norm_type == "log":
             if array_min <= 0:
-                v_min = 1e-5
+                v_min = 1e-1
             else:
                 v_min = array_min
             if array_max <= 0:
@@ -2433,6 +2507,16 @@ def array_to_image(
             "Either both v_min and v_max must be specified or neither can be specified"
         )
 
+    # Assign "cmap" based on the input "key"
+    if cmap is None:
+        if "sky_backgrounds" in key:
+            cmap = "inferno"
+        elif "exposure_maps" in key:
+            cmap = "cividis"
+        elif "lexi_images" in key:
+            cmap = "plasma"
+        else:
+            cmap = "viridis"
     # Create the figure
     fig, ax = plt.subplots(
         figsize=figure_size, dpi=dpi, facecolor=facecolor, edgecolor=edgecolor
@@ -2489,7 +2573,7 @@ def array_to_image(
     )
     if show_colorbar:
         if cbar_label is None:
-            cbar_label = "Value"
+            cbar_label = "Counts/sec"
         if cbar_orientation == "vertical":
             cax = fig.add_axes(
                 [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lexi_xray"
-version = "0.4.1"
+version = "0.4.2"
 description = "A python package for data analysis related to LEXI"
 authors = ["qudsiramiz <qudsiramiz@gmail.com>"]
 maintainers = [


### PR DESCRIPTION
1.  Modified the code so that the extra images that were being generate are no longer being generated.
2. Modified the way we were computing `integ_groups` for different functions, so that it is now consistent throughout the code. 
3. In the `make_lexi_images` function, the final images were not being produced correctly. The units were counts instead of counts/second. Fixed this issue.
4. In the `make_lexi_images` function, while doing background subtraction, the background was in counts/second however, LEXI counts were just counts. Fixed it now so that they both are in counts/second.
5. The `array_to_image` function, based on the type of input, makes plots with different kinds of `cmap`. For example, if it is making `lexi` image, unless a different value of `cmap` is provided, it will always use `plasma`, whereas for sky backgrounds, it will use `inferno`. If any other key is provided, the function will default to using `viridis`.
6. `make_lexi_images` function now also returns the values of background arrays, as well as exposure maps.
7. `calc_sky_backgrounds` function now also return the value of exposure maps.